### PR TITLE
feat: Refine publicly exposed types

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,6 +26,9 @@ jobs:
         uses: jdx/mise-action@v2
         with:
           install: true
+        env:
+          MISE_HTTP_TIMEOUT: 300
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout gh-pages Branch
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,9 @@ jobs:
         uses: jdx/mise-action@v2
         with:
           install: true
+        env:
+          MISE_HTTP_TIMEOUT: 300
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test iOS
         run: >

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 1. [Installation](#installation)
 2. [Basic Usage](#basic-usage)
-3. [Making Your App Themeable](#make-your-app-themeable)
+3. [Make Your App Themeable](#make-your-app-themeable)
 4. [Documentation](#documentation)
 5. [License](#license)
 

--- a/Sources/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/Documentation.docc/Articles/GettingStarted.md
@@ -9,7 +9,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/alexanderwe/swiftui-theming",
-      from: "0.1.0"
+      from: "0.1.1"
     ),
   ],
   targets: [

--- a/Sources/Theming/Theme.swift
+++ b/Sources/Theming/Theme.swift
@@ -83,10 +83,22 @@ public struct Theme: Sendable, Identifiable {
     }
 
     // MARK: - Methods
+
+    /// Get a color for the requested color style and traits.
+    ///
+    /// - Parameters:
+    ///   - style: The style to resolve a color for.
+    ///   - traits: The traits used to resolve the color.
+    /// - Returns: A color for the given parameters. Returns nil if no matching color is found.
     func color(for style: ThemeColorStyle, with traits: ThemeTraits) -> Color? {
         colors[style]?.resolve(with: traits)
     }
 
+    /// Get a font for the requested style.
+    ///
+    /// - Parameters:
+    ///   - style: The style to resolve a font for.
+    /// - Returns: A font for the given parameters. Returns nil if no matching font is found.
     func font(for style: Font.TextStyle) -> Font? {
         fonts[style]
     }

--- a/Sources/Theming/ThemeTraits.swift
+++ b/Sources/Theming/ThemeTraits.swift
@@ -10,17 +10,17 @@ import SwiftUI
 import UIKit
 #endif
 
-// MARK: - ThemeColorTraits
+// MARK: - ThemeTraits
 #if os(visionOS) || os(iOS)
 /// Traits important for a theme.
-public typealias ThemeTraits = (
+typealias ThemeTraits = (
     colorScheme: ColorScheme,
     colorSchemeContrast: ColorSchemeContrast,
     interfaceLevel: UIUserInterfaceLevel
 )
 #elseif os(watchOS) || os(tvOS) || os(macOS)
 /// Traits important for a theme.
-public typealias ThemeTraits = (colorScheme: ColorScheme, colorSchemeContrast: ColorSchemeContrast)
+typealias ThemeTraits = (colorScheme: ColorScheme, colorSchemeContrast: ColorSchemeContrast)
 #endif
 
 extension EnvironmentValues {


### PR DESCRIPTION
### Short description 📝

This PR removes `ThemeTraits` from being publicly available. The type is not necessary to be exposed. In addition it uses concepts that are only used within `Theming`. Therefore it is more clean to have it not publicly available. 

In addition this PR also adapts some code comments as well as the Getting Started guide. 